### PR TITLE
modified require to require_dependency

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,4 @@
-require 'redmine_webhook'
+require_dependency 'redmine_webhook'
 
 Rails.configuration.to_prepare do
   unless ProjectsHelper.included_modules.include? RedmineWebhook::ProjectsHelperPatch


### PR DESCRIPTION
I think should use `require_dependency` in this scene.

I tried install redmine_webhook to my redmine. But, I ran into the following error.
And, it worked fine After modify `require` to `require_dependency`.
- Amazon Linux AMI 2014.09 (HVM) 
- Redmine 2.5.2
- Ruby 2.0.0p481
- Rails 3.2.19
- rake 10.1.1

error log

```
[ec2-user@ip-XXX-XX-X-XX redmine]$ rake redmine:plugins:migrate RAILS_ENV=production
rake aborted!
Expected /var/lib/redmine/plugins/redmine_webhook/lib/redmine_webhook.rb to define RedmineWebhook
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:503:in `load_missing_constant'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:192:in `block in const_missing'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:190:in `each'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:190:in `const_missing'
/var/lib/redmine/plugins/redmine_webhook/lib/redmine_webhook/projects_helper_patch.rb:2:in `<top (required)>'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `block in require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/var/lib/redmine/plugins/redmine_webhook/lib/redmine_webhook.rb:1:in `<top (required)>'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `block in require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/var/lib/redmine/plugins/redmine_webhook/init.rb:1:in `<top (required)>'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `block in require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/var/lib/redmine/lib/redmine/plugin.rb:133:in `block in load'
/var/lib/redmine/lib/redmine/plugin.rb:124:in `each'
/var/lib/redmine/lib/redmine/plugin.rb:124:in `load'
/var/lib/redmine/config/initializers/30-redmine.rb:19:in `<top (required)>'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:245:in `load'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:245:in `block in load'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:245:in `load'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/engine.rb:593:in `block (2 levels) in <class:Engine>'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/engine.rb:592:in `each'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/engine.rb:592:in `block in <class:Engine>'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/initializable.rb:30:in `instance_exec'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/initializable.rb:30:in `run'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/initializable.rb:55:in `block in run_initializers'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/initializable.rb:54:in `each'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/initializable.rb:54:in `run_initializers'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/application.rb:136:in `initialize!'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/railtie/configurable.rb:30:in `method_missing'
/var/lib/redmine/config/environment.rb:14:in `<top (required)>'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `block in require'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
/home/ec2-user/.gem/ruby/2.0/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/application.rb:103:in `require_environment!'
/home/ec2-user/.gem/ruby/2.0/gems/railties-3.2.19/lib/rails/application.rb:305:in `block (2 levels) in initialize_tasks'
Tasks: TOP => redmine:plugins:migrate => environment
(See full trace by running task with --trace)
```
