### PR TITLE
Support redmine 3.0

### DIFF
--- a/app/controllers/webhook_settings_controller.rb
+++ b/app/controllers/webhook_settings_controller.rb
@@ -2,7 +2,7 @@ class WebhookSettingsController < ApplicationController
   before_filter :find_project
 
   def update
-    webhook = Webhook.where(:project_id => @project.id).first || Webhook.new(:project_id => @project.id)
+    webhook = Webhook.where(:project_id => @project.id).first_or_create
     webhook.url = params[:url]
     if webhook.save
       flash[:notice] = l(:notice_successful_update)


### PR DESCRIPTION
It get mass-assignment protection error with redmine 3.0.x
It is because rails 4 use strong parameters.
This fix mass-assignment protection error for protected project_id attribute.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>