### PR TITLE
Allow requests to prevent triggering webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Requirements
 * Redmine 2.4, 2.6, 3.0
 
 
+Skipping webhooks
+------------------------------
+When a webhook triggers a change via REST API, this would trigger another webhook.
+If you need to prevent this, the API request can include the `X-Skip-Webhooks` header, which will prevent webhooks being triggered by that request.
+
+
 Known Limitations
 ------------------------------
 

--- a/lib/redmine_webhook/webhook_listener.rb
+++ b/lib/redmine_webhook/webhook_listener.rb
@@ -1,7 +1,16 @@
 module RedmineWebhook
   class WebhookListener < Redmine::Hook::Listener
 
+    def skip_webhooks(context)
+      request = context[:request]
+      if request.headers['X-Skip-Webhooks']
+        return true
+      end
+      return false
+    end
+
     def controller_issues_new_after_save(context = {})
+      return if skip_webhooks(context)
       issue = context[:issue]
       controller = context[:controller]
       project = issue.project
@@ -11,6 +20,7 @@ module RedmineWebhook
     end
 
     def controller_issues_edit_after_save(context = {})
+      return if skip_webhooks(context)
       journal = context[:journal]
       controller = context[:controller]
       issue = context[:issue]


### PR DESCRIPTION
Taken from: AdmanTIC/redmine_webhook@cb8c6fda119e0d3f8d9bcf2f90497d1861014f41

This is useful when a webhook triggers an edit, which would then trigger an unnecesary webook again.