### PR TITLE
Fixes and merges from other repos

### DIFF
--- a/app/controllers/webhook_settings_controller.rb
+++ b/app/controllers/webhook_settings_controller.rb
@@ -20,7 +20,9 @@ class WebhookSettingsController < ApplicationController
     id = params[:webhook_id]
     webhook = Webhook.where(:project_id => @project.id).where(:id => id).first
     webhook.url = params[:url]
-    if webhook.save
+    if webhook.url.empty?
+      webhook.destroy
+    elsif webhook.save
       flash[:notice] = l(:notice_successful_update_webhook)
     else
       flash[:error] = l(:notice_fail_update_webhook)

--- a/lib/redmine_webhook/webhook_listener.rb
+++ b/lib/redmine_webhook/webhook_listener.rb
@@ -15,6 +15,7 @@ module RedmineWebhook
       controller = context[:controller]
       project = issue.project
       webhooks = Webhook.where(:project_id => project.project.id)
+      webhooks = Webhook.where(:project_id => 0) unless webhooks && webhooks.length > 0
       return unless webhooks
       post(webhooks, issue_to_json(issue, controller))
     end
@@ -26,8 +27,30 @@ module RedmineWebhook
       issue = context[:issue]
       project = issue.project
       webhooks = Webhook.where(:project_id => project.project.id)
+      webhooks = Webhook.where(:project_id => 0) unless webhooks && webhooks.length > 0
       return unless webhooks
       post(webhooks, journal_to_json(issue, journal, controller))
+    end
+
+    def controller_issues_bulk_edit_after_save(context = {})
+      return if skip_webhooks(context)
+      journal = context[:journal]
+      controller = context[:controller]
+      issue = context[:issue]
+      project = issue.project
+      webhooks = Webhook.where(:project_id => project.project.id)
+      webhooks = Webhook.where(:project_id => 0) unless webhooks && webhooks.length > 0
+      return unless webhooks
+      post(webhooks, journal_to_json(issue, journal, controller))
+    end
+
+    def model_changeset_scan_commit_for_issue_ids_pre_issue_update(context = {})
+      issue = context[:issue]
+      journal = issue.current_journal
+      webhooks = Webhook.where(:project_id => issue.project.project.id)
+      webhooks = Webhook.where(:project_id => 0) unless webhooks && webhooks.length > 0
+      return unless webhooks
+      post(webhooks, journal_to_json(issue, journal, nil))
     end
 
     private
@@ -47,7 +70,7 @@ module RedmineWebhook
           :action => 'updated',
           :issue => RedmineWebhook::IssueWrapper.new(issue).to_hash,
           :journal => RedmineWebhook::JournalWrapper.new(journal).to_hash,
-          :url => controller.issue_url(issue)
+          :url => controller.nil? ? 'not yet implemented' : controller.issue_url(issue)
         }
       }.to_json
     end


### PR DESCRIPTION
Changes:

- fix: handle empty webhook url
  * I cant recall if i wrote or if it was cherry picked from another fork.
- feature: emit webhook for bulk edit or fetch changeset
  * Make webhooks compatible with the `controller_issues_bulk_edit_after_save` patch: [Redmine issue #8757](https://www.redmine.org/issues/8757)
  * Taken from AdmanTIC/redmine_webhook@971640c8fb2e70aa204047f1639a89758e14d439
- feature: Add default webhook configuration if absent from project
  * Taken from AdmanTIC/redmine_webhook@971640c8fb2e70aa204047f1639a89758e14d439
  * No UI for this, save a webhook with a `project_id` of `0` in the database.