### PR TITLE
Other Redmine plugins compatibility

### DIFF
--- a/app/views/webhook_settings/_show.html.erb
+++ b/app/views/webhook_settings/_show.html.erb
@@ -1,5 +1,3 @@
-
-<% if User.current.allowed_to?( :manage_hook, @project) %>
 <% if Webhook.where(:project_id => @project.id).first%>
 <div class="box tabular">
 <% Webhook.where(:project_id => @project.id).each do |webhook|%>
@@ -15,6 +13,7 @@
 <% end %>
 </div>
 <% end %>
+
 <%= form_tag(create_webhook_path(@project), :method => :post, :class => "tabular") do %>
 <div class="box tabular">
 <span>
@@ -23,8 +22,4 @@
   <%= submit_tag l(:button_add) %>
 </span>
 </div>
-
-
-<% end %>
-
 <% end %>

--- a/init.rb
+++ b/init.rb
@@ -7,5 +7,7 @@ Redmine::Plugin.register :redmine_webhook do
   version '0.0.5'
   url 'https://github.com/suer/redmine_webhook'
   author_url 'http://d.hatena.ne.jp/suer'
-  permission :manage_hook, {:webhook_settings => [:index, :show, :update, :create, :destroy]}, :require => :member
+  project_module :webhooks do
+    permission :manage_hook, {:webhook_settings => [:index, :show, :update, :create, :destroy]}, :require => :member
+  end
 end

--- a/lib/redmine_webhook/projects_helper_patch.rb
+++ b/lib/redmine_webhook/projects_helper_patch.rb
@@ -2,15 +2,17 @@ module RedmineWebhook
   module ProjectsHelperPatch
     def project_settings_tabs
       tabs = super
-      tabs << {
+      webhook_tab = {
         :name => 'webhook',
         :controller => 'webhook_settings',
         :action => :show,
         :partial => 'webhook_settings/show',
         :label => :webhook
       }
+      tabs << webhook_tab if User.current.allowed_to?(:manage_hook, @project)
+      tabs
     end
   end
-
-  ProjectsHelper.prepend ProjectsHelperPatch
 end
+
+ProjectsController.send(:helper, RedmineWebhook::ProjectsHelperPatch)


### PR DESCRIPTION
 To those who have lost this plugin settings tab (#26, #32, #34)

- Redmine is patching some other way, so plugin should not conflict with other plugins redefining **Settings** tabs set (including `redmine_dmsf`)
- _Manage hook_ permission moved from **Project** section to its own **Webhooks**
- Webhook settings tab won't be shown at all if current user has no _manage hook_ permission