### PR TITLE
Added HMAC signature to webhook payloads

### DIFF
--- a/app/controllers/webhook_settings_controller.rb
+++ b/app/controllers/webhook_settings_controller.rb
@@ -9,6 +9,7 @@ class WebhookSettingsController < ApplicationController
   def create
     webhook = Webhook.new(:project_id => @project.id)
     webhook.url = params[:url]
+    webhook.secret_key = params[:secret_key]
     if webhook.save
       flash[:notice] = l(:notice_successful_create_webhook)
     else
@@ -20,6 +21,7 @@ class WebhookSettingsController < ApplicationController
     id = params[:webhook_id]
     webhook = Webhook.where(:project_id => @project.id).where(:id => id).first
     webhook.url = params[:url]
+    webhook.secret_key = params[:secret_key]
     if webhook.url.blank? ? webhook.destroy : webhook.save
       flash[:notice] = l(:notice_successful_update_webhook)
     else

--- a/app/views/webhook_settings/_show.html.erb
+++ b/app/views/webhook_settings/_show.html.erb
@@ -5,6 +5,8 @@
 <span>
   <span><strong>URL</strong></span>
   <%= text_field_tag :url, webhook.url, :size => 80 %>
+  <span><strong>Secret key</strong></span>
+  <%= password_field_tag :secret_key, webhook.secret_key, :size => 40 %>
   <%= submit_tag l(:button_update) %>
 </span>
 <% end %>
@@ -19,6 +21,8 @@
 <span>
   <span><strong>URL</strong></span>
   <%= text_field_tag :url, '', :size => 80 %>
+  <span><strong>Secret key</strong></span>
+  <%= password_field_tag :secret_key, '', :size => 40 %>
   <%= submit_tag l(:button_add) %>
 </span>
 </div>

--- a/db/migrate/20221023_add_webhook_secret_key.rb
+++ b/db/migrate/20221023_add_webhook_secret_key.rb
@@ -1,0 +1,5 @@
+class AddWebhookSecretKey < ActiveRecord::Migration[4.2]
+    def change
+      add_column :webhooks, :secret_key, :text
+    end
+  end


### PR DESCRIPTION
This implemented the feature requested in #9 .

## Changes

* NEW: "secret_key" text field in Webhook model.
* NEW: Webhook view & controller modified to include secret_key text field (tagged as password field in the view).
* NEW: Webhook posts contain two new headers.
  - `X-RedmineWebhook-HMAC-Alg`: The algorithm used for the HMAC signature. Currently hard-coded as `sha1`.
  - `X-RedmineWebhook-HMAC-Signature`: The HMAC signature.

## Testing

The changes were tested against the latest docker redmine container (5.0.3 at the time of this PR). A small Python Flask server was written to perform the HMAC validation that clients are expected to do (can be [found in this gist](https://gist.github.com/ricekab/abeab41b3b4771d9f2bd5ce4e9a2e2f0)).

I've tested with three configurations: (1) an incorrect key, (2) a correct key, and (3) no key.
![image](https://user-images.githubusercontent.com/7865340/197396351-ef7fd973-20ce-481b-81d5-83a27484f62e.png)

The Flask web server output for this is:

```
Project: examplebadkey
Alg: sha1
Signature: 89b3f8de7175044d4f772ec3ce7b6741aa852431
Calculated signature: b9ad1a2263b192d7d8978d13f0cb8d8ed68175d8
HMAC verification failed, payload is malformed or tampered!
HMAC verification succeeded: False
172.18.0.2 - - [23/Oct/2022 13:42:28] "POST /redminewebhook/examplebadkey HTTP/1.1" 200 -

Project: goodkey
Alg: sha1
Signature: b9ad1a2263b192d7d8978d13f0cb8d8ed68175d8
Calculated signature: b9ad1a2263b192d7d8978d13f0cb8d8ed68175d8
HMAC verification succeeded: True
172.18.0.2 - - [23/Oct/2022 13:42:28] "POST /redminewebhook/goodkey HTTP/1.1" 200 -

Project: nokey
Alg: sha1
Signature: 2880f307aa1ba774c716279b26542d6011e5fe6b
Calculated signature: b9ad1a2263b192d7d8978d13f0cb8d8ed68175d8
HMAC verification failed, payload is malformed or tampered!
HMAC verification succeeded: False
172.18.0.2 - - [23/Oct/2022 13:42:28] "POST /redminewebhook/nokey HTTP/1.1" 200 -
```

## Potential issues / improvements

* The algorithm used for the digest is hard-coded to use SHA1. This should be configurable to some extent.
* This is **potentially a breaking change** with existing webhook setups. I'm not sure how database migrations work with existing entries. If the secret_key is not a proper text entry (ie. null), I expect this code could break.

## Additional notes

* I followed the naming convention (somewhat) for db migrations from the main redmine project, prepending the date at the front in YYYYMMDD format.
* I do not have much experience with Ruby development, verification from a maintainer regarding code quality would be much appreciated.